### PR TITLE
Fix: 댓글 삭제불가 버그 수정

### DIFF
--- a/backend/src/main/java/site/gongnomok/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/site/gongnomok/domain/comment/service/CommentService.java
@@ -2,6 +2,7 @@ package site.gongnomok.domain.comment.service;
 
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.gongnomok.domain.comment.dto.*;
@@ -21,6 +22,7 @@ import java.util.List;
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class CommentService {
 
     private final ItemRepository itemRepository;
@@ -68,7 +70,7 @@ public class CommentService {
             .orElseThrow(() -> new CannotFindCommentByIdException("존재하지 않는 댓글입니다."));
 
         String encryptedPassword = SecurityUtil.encryptSha256(deleteDto.getPassword());
-        if (encryptedPassword.equals(findComment.getPassword())) {
+        if (!encryptedPassword.equals(findComment.getPassword())) {
             throw new CommentPasswordNotMatchException("패스워드가 일치하지 않습니다.");
         }
 

--- a/backend/src/test/java/site/gongnomok/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/site/gongnomok/domain/comment/service/CommentServiceTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import site.gongnomok.domain.comment.dto.*;
+import site.gongnomok.domain.comment.exception.CommentPasswordNotMatchException;
 import site.gongnomok.global.entity.Comment;
 import site.gongnomok.global.util.SecurityUtil;
 
@@ -102,8 +103,32 @@ class CommentServiceTest {
             .build();
 
         commentService.deleteComment(deleteDto);
+    }
 
-        //then
+    @Test
+    @DisplayName("댓글 비밀번호 불일치 삭제 실패")
+    void comment_delete_fail_password_mismatch() {
+        //given
+        String PASSWORD = "1234321";
+        String WRONG_PASSWORD = "1234";
+
+        CommentCreateServiceDto createDto = CommentCreateServiceDto.builder()
+            .name("user")
+            .password(PASSWORD)
+            .content("comment content")
+            .build();
+
+        CommentCreateResponse createCommentInfo = commentService.createComment(createDto, 5L);
+
+        //when, then
+        CommentDeleteServiceDto deleteDto = CommentDeleteServiceDto.builder()
+            .commentId(createCommentInfo.getCommentId())
+            .password(WRONG_PASSWORD)
+            .build();
+
+        assertThrows(CommentPasswordNotMatchException.class, () -> {
+            commentService.deleteComment(deleteDto);
+        });
     }
 
 }

--- a/backend/src/test/java/site/gongnomok/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/site/gongnomok/domain/comment/service/CommentServiceTest.java
@@ -6,9 +6,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-import site.gongnomok.domain.comment.dto.CommentCreateResponse;
-import site.gongnomok.domain.comment.dto.CommentCreateServiceDto;
-import site.gongnomok.domain.comment.dto.CommentResponse;
+import site.gongnomok.domain.comment.dto.*;
+import site.gongnomok.global.entity.Comment;
 import site.gongnomok.global.util.SecurityUtil;
 
 import java.util.List;
@@ -78,6 +77,33 @@ class CommentServiceTest {
     @DisplayName("아이템 댓글 No Offset")
     void comment_no_offset_page() {
 
+    }
+
+
+    @Test
+    @DisplayName("댓글 삭제 성공")
+    void comment_delete() {
+
+        //given
+        String PASSWORD = "1234321";
+        Long itemId = 5L;
+
+        CommentCreateServiceDto createDto = CommentCreateServiceDto.builder()
+            .name("user")
+            .password(PASSWORD)
+            .content("comment content")
+            .build();
+        CommentCreateResponse createCommentInfo = commentService.createComment(createDto, 5L);
+
+        //when
+        CommentDeleteServiceDto deleteDto = CommentDeleteServiceDto.builder()
+            .commentId(createCommentInfo.getCommentId())
+            .password(PASSWORD)
+            .build();
+
+        commentService.deleteComment(deleteDto);
+
+        //then
     }
 
 }


### PR DESCRIPTION
- 댓글의 비밀번호가 일치해도 삭제할 수 없는 버그를 수정하였습니다.
- 댓글 삭제 테스트코드를 작성하였습니다.