### PR TITLE
fix: 댓글을 바로 삭제할 수 없는 버그 수정

### DIFF
--- a/frontend/src/components/Item/comment/Comment.jsx
+++ b/frontend/src/components/Item/comment/Comment.jsx
@@ -126,7 +126,7 @@ export default function Comment({ itemId }) {
       .then((res) => {
         const data = res.data;
         const newComment = {
-          commendId: data.commentId,
+          commentId: data.commentId,
           name: data.name,
           content: commentForm.content,
           createdDate: data.createdDate
@@ -169,9 +169,10 @@ export default function Comment({ itemId }) {
   function handleDelete(commentId) {
     // 모달창을 띄우고 패스워드를 입력받는다.
     setModalOpen(true);
-
     const copy = { ...commentDeleteForm };
     copy.commentId = commentId;
+
+
     setCommentDeleteForm(copy);
   }
 

--- a/frontend/src/global/uri.js
+++ b/frontend/src/global/uri.js
@@ -1,8 +1,8 @@
 // export const BASE_URI = "http://34.64.91.129:8080"
-// export const BASE_URI = "http://localhost:8080"
+export const BASE_URI = "http://localhost:8080"
 // export const BASE_URI = "//gongnomok.site:8080"
 // export const BASE_URI = "https://gongnomok.site:8080"
-export const BASE_URI = "http://gongnomok.site"
+// export const BASE_URI = "http://gongnomok.site"
 
 
 


### PR DESCRIPTION
- 방금 작성한 댓글을 바로 삭제할 수 없는 버그를 수정하였습니다.

<img width="759" alt="스크린샷 2024-03-08 오전 5 30 29" src="https://github.com/mynameisjaehoon/gongnomok-simulator/assets/76734067/5b3e8ed9-7fa0-4d82-b32c-54ba3b3aaf27">

새로운 댓글을 추가한 후 객체를 생성할 때 commentId를 commen`d`Id로 잘못 작성해서 발생한 문제였습니다.