### PR TITLE
bugfix: 최고기록을 조작할 수 있는 버그 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation group: 'com.vladmihalcea', name: 'hibernate-types-52', version: '1.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator' //액츄에이터
 	implementation 'io.micrometer:micrometer-registry-prometheus' //프로메테우스
+	runtimeOnly 'com.h2database:h2' // H2
 
 	compileOnly 'org.projectlombok:lombok'
 

--- a/backend/src/main/generated/site/gongnomok/comment/domain/QComment.java
+++ b/backend/src/main/generated/site/gongnomok/comment/domain/QComment.java
@@ -1,4 +1,4 @@
-package site.gongnomok.global.entity;
+package site.gongnomok.comment.domain;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
@@ -8,7 +8,6 @@ import com.querydsl.core.types.PathMetadata;
 import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.PathInits;
-import site.gongnomok.comment.domain.Comment;
 
 
 /**
@@ -17,7 +16,7 @@ import site.gongnomok.comment.domain.Comment;
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QComment extends EntityPathBase<Comment> {
 
-    private static final long serialVersionUID = 74191153L;
+    private static final long serialVersionUID = 2024669298L;
 
     private static final PathInits INITS = PathInits.DIRECT2;
 
@@ -29,7 +28,7 @@ public class QComment extends EntityPathBase<Comment> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
-    public final QItem item;
+    public final site.gongnomok.item.domain.QItem item;
 
     public final StringPath name = createString("name");
 
@@ -53,7 +52,7 @@ public class QComment extends EntityPathBase<Comment> {
 
     public QComment(Class<? extends Comment> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.item = inits.isInitialized("item") ? new QItem(forProperty("item")) : null;
+        this.item = inits.isInitialized("item") ? new site.gongnomok.item.domain.QItem(forProperty("item")) : null;
     }
 
 }

--- a/backend/src/main/generated/site/gongnomok/enhanceditem/domain/QEnhancedItem.java
+++ b/backend/src/main/generated/site/gongnomok/enhanceditem/domain/QEnhancedItem.java
@@ -1,4 +1,4 @@
-package site.gongnomok.global.entity;
+package site.gongnomok.enhanceditem.domain;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
@@ -8,7 +8,6 @@ import com.querydsl.core.types.PathMetadata;
 import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.PathInits;
-import site.gongnomok.enhanceditem.domain.EnhancedItem;
 
 
 /**
@@ -17,7 +16,7 @@ import site.gongnomok.enhanceditem.domain.EnhancedItem;
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QEnhancedItem extends EntityPathBase<EnhancedItem> {
 
-    private static final long serialVersionUID = 1140828183L;
+    private static final long serialVersionUID = -206638276L;
 
     private static final PathInits INITS = PathInits.DIRECT2;
 
@@ -37,7 +36,7 @@ public class QEnhancedItem extends EntityPathBase<EnhancedItem> {
 
     public final NumberPath<Integer> intel = createNumber("intel", Integer.class);
 
-    public final QItem item;
+    public final site.gongnomok.item.domain.QItem item;
 
     public final NumberPath<Integer> jump = createNumber("jump", Integer.class);
 
@@ -79,7 +78,7 @@ public class QEnhancedItem extends EntityPathBase<EnhancedItem> {
 
     public QEnhancedItem(Class<? extends EnhancedItem> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.item = inits.isInitialized("item") ? new QItem(forProperty("item")) : null;
+        this.item = inits.isInitialized("item") ? new site.gongnomok.item.domain.QItem(forProperty("item")) : null;
     }
 
 }

--- a/backend/src/main/generated/site/gongnomok/item/domain/QItem.java
+++ b/backend/src/main/generated/site/gongnomok/item/domain/QItem.java
@@ -1,4 +1,4 @@
-package site.gongnomok.global.entity;
+package site.gongnomok.item.domain;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
@@ -7,9 +7,6 @@ import com.querydsl.core.types.dsl.*;
 import com.querydsl.core.types.PathMetadata;
 import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
-import site.gongnomok.item.domain.AttackSpeed;
-import site.gongnomok.item.domain.Category;
-import site.gongnomok.item.domain.Item;
 
 
 /**
@@ -18,7 +15,7 @@ import site.gongnomok.item.domain.Item;
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QItem extends EntityPathBase<Item> {
 
-    private static final long serialVersionUID = 1876990337L;
+    private static final long serialVersionUID = -392478672L;
 
     public static final QItem item = new QItem("item");
 

--- a/backend/src/main/generated/site/gongnomok/member/domain/QMember.java
+++ b/backend/src/main/generated/site/gongnomok/member/domain/QMember.java
@@ -1,4 +1,4 @@
-package site.gongnomok.global.entity;
+package site.gongnomok.member.domain;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
@@ -7,8 +7,6 @@ import com.querydsl.core.types.dsl.*;
 import com.querydsl.core.types.PathMetadata;
 import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
-import site.gongnomok.member.domain.Member;
-import site.gongnomok.member.domain.Role;
 
 
 /**
@@ -17,7 +15,7 @@ import site.gongnomok.member.domain.Role;
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QMember extends EntityPathBase<Member> {
 
-    private static final long serialVersionUID = 2344328L;
+    private static final long serialVersionUID = 1972555838L;
 
     public static final QMember member = new QMember("member1");
 

--- a/backend/src/main/java/site/gongnomok/comment/domain/repository/CommentQueryRepository.java
+++ b/backend/src/main/java/site/gongnomok/comment/domain/repository/CommentQueryRepository.java
@@ -11,7 +11,8 @@ import site.gongnomok.comment.dto.response.CommentResponse;
 
 import java.util.List;
 
-import static site.gongnomok.global.entity.QComment.comment;
+import static site.gongnomok.comment.domain.QComment.comment;
+
 
 @Slf4j
 @Repository

--- a/backend/src/main/java/site/gongnomok/comment/presentation/CommentController.java
+++ b/backend/src/main/java/site/gongnomok/comment/presentation/CommentController.java
@@ -10,7 +10,6 @@ import site.gongnomok.comment.dto.request.CommentDeleteDto;
 import site.gongnomok.comment.dto.response.CommentCountResponse;
 import site.gongnomok.comment.dto.response.CommentCreateResponse;
 import site.gongnomok.comment.dto.response.CommentResponse;
-import site.gongnomok.domain.comment.dto.*;
 import site.gongnomok.comment.service.CommentService;
 
 import java.util.List;

--- a/backend/src/main/java/site/gongnomok/comment/service/CommentService.java
+++ b/backend/src/main/java/site/gongnomok/comment/service/CommentService.java
@@ -14,7 +14,6 @@ import site.gongnomok.comment.exception.CannotFindItemCommentException;
 import site.gongnomok.comment.exception.CommentPasswordNotMatchException;
 import site.gongnomok.comment.domain.repository.CommentJpaRepository;
 import site.gongnomok.comment.domain.repository.CommentQueryRepository;
-import site.gongnomok.domain.comment.dto.*;
 import site.gongnomok.item.domain.repository.ItemRepository;
 import site.gongnomok.comment.domain.Comment;
 import site.gongnomok.item.domain.Item;

--- a/backend/src/main/java/site/gongnomok/enhanceditem/ValidationCategory.java
+++ b/backend/src/main/java/site/gongnomok/enhanceditem/ValidationCategory.java
@@ -47,7 +47,7 @@ public enum ValidationCategory {
         return upgradableCount * singleUpgradableValue;
     }
 
-    public ValidationCategory findWithName(String name) {
+    public static ValidationCategory findWithName(String name) {
         return Arrays
             .stream(values())
             .filter(value -> value.name().equals(name))

--- a/backend/src/main/java/site/gongnomok/enhanceditem/ValidationCategory.java
+++ b/backend/src/main/java/site/gongnomok/enhanceditem/ValidationCategory.java
@@ -1,5 +1,10 @@
 package site.gongnomok.enhanceditem;
 
+import site.gongnomok.enhanceditem.exception.CannotFindCategoryException;
+
+import java.util.Arrays;
+import java.util.Optional;
+
 public enum ValidationCategory {
 
     HAT(7, 9), // 모자
@@ -40,5 +45,13 @@ public enum ValidationCategory {
 
     public int getMaximumUpgradableValue() {
         return upgradableCount * singleUpgradableValue;
+    }
+
+    public ValidationCategory findWithName(String name) {
+        return Arrays
+            .stream(values())
+            .filter(value -> value.name().equals(name))
+            .findAny()
+            .orElseThrow(CannotFindCategoryException::new);
     }
 }

--- a/backend/src/main/java/site/gongnomok/enhanceditem/ValidationCategory.java
+++ b/backend/src/main/java/site/gongnomok/enhanceditem/ValidationCategory.java
@@ -1,0 +1,44 @@
+package site.gongnomok.enhanceditem;
+
+public enum ValidationCategory {
+
+    HAT(7, 9), // 모자
+    GLOVES(5, 9), // 장갑
+    SHOES(5, 9), // 신발
+    OVERALL(10, 9), // 전신
+    TOP(7, 9), // 상의
+    BOTTOM(7, 9), // 하의
+    SHIELD(7, 9), // 방패
+    EARRING(5, 9), // 귀고리
+    CAPE(5, 9), // 망토
+    ONE_HANDED_SWORD(7, 11), // 한손검
+    TWO_HANDED_SWORD(7, 11), // 두손검
+    ONE_HANDED_AXE(7, 11), // 한손도끼
+    TWO_HANDED_AXE(7, 11), // 두손도끼
+    ONE_HANDED_BLUNT(7, 11), // 한손둔기
+    TWO_HANDED_BLUNT(7, 11), // 두손둔기
+    SPEAR(7, 11), // 창
+    POLEARM(7, 11), // 폴암
+    BOW(7, 9), // 활
+    CROSSBOW(7, 9), // 석궁
+    CLAW(7, 9), // 아대
+    DAGGER(7, 9), // 단검
+    WAND(7, 9), // 완드
+    STAFF(7, 9); // 스태프
+
+    private final int upgradableCount;
+    private final int singleUpgradableValue;
+
+    ValidationCategory(int upgradableCount, int singleUpgradableValue) {
+        this.upgradableCount = upgradableCount;
+        this.singleUpgradableValue = singleUpgradableValue;
+    }
+
+    public int getUpgradableCount() {
+        return upgradableCount;
+    }
+
+    public int getMaximumUpgradableValue() {
+        return upgradableCount * singleUpgradableValue;
+    }
+}

--- a/backend/src/main/java/site/gongnomok/enhanceditem/exception/CannotFindCategoryException.java
+++ b/backend/src/main/java/site/gongnomok/enhanceditem/exception/CannotFindCategoryException.java
@@ -1,0 +1,24 @@
+package site.gongnomok.enhanceditem.exception;
+
+public class CannotFindCategoryException extends RuntimeException {
+
+    public CannotFindCategoryException() {
+        super();
+    }
+
+    public CannotFindCategoryException(String message) {
+        super(message);
+    }
+
+    public CannotFindCategoryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CannotFindCategoryException(Throwable cause) {
+        super(cause);
+    }
+
+    protected CannotFindCategoryException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/backend/src/main/java/site/gongnomok/enhanceditem/presentation/EnhancedItemController.java
+++ b/backend/src/main/java/site/gongnomok/enhanceditem/presentation/EnhancedItemController.java
@@ -30,6 +30,7 @@ public class EnhancedItemController {
         @PathVariable("itemId") Long itemId,
         @RequestBody ItemEnhanceRequest enhanceDto
     ) {
+
         UpdateEnhancementResponse response = enhancedItemService.updateEnhanceItem(itemId, enhanceDto.toServiceDto());
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/site/gongnomok/enhanceditem/service/EnhancedItemService.java
+++ b/backend/src/main/java/site/gongnomok/enhanceditem/service/EnhancedItemService.java
@@ -4,6 +4,7 @@ package site.gongnomok.enhanceditem.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.gongnomok.enhanceditem.ValidationCategory;
 import site.gongnomok.enhanceditem.domain.EnhancedItem;
 import site.gongnomok.enhanceditem.domain.repository.EnhancedItemRepository;
 import site.gongnomok.enhanceditem.dto.EnhanceResult;
@@ -55,6 +56,10 @@ public class EnhancedItemService {
         final ItemEnhanceServiceRequest enhanceDto
     ) {
 
+        if (validateEnhanceRequest(enhanceDto)) {
+            return new UpdateEnhancementResponse(EnhanceResult.FAIL);
+        }
+
         Optional<EnhancedItem> enhancedItemOptional = itemRepository.findEnhanceItem(itemId);
         if (enhancedItemOptional.isEmpty()) {
             return createEnhancedRecord(itemId, enhanceDto);
@@ -70,6 +75,17 @@ public class EnhancedItemService {
 
         // 기록이 기존의 것보다 낮을 경우
         return new UpdateEnhancementResponse(EnhanceResult.FAIL);
+    }
+
+    private boolean validateEnhanceRequest(ItemEnhanceServiceRequest request) {
+        ValidationCategory findCategory = ValidationCategory.findWithName(request.getCategory());
+        if (request.getIev() > findCategory.getMaximumUpgradableValue()) {
+            return false;
+        }
+        if (request.getSuccessCount() > findCategory.getUpgradableCount()) {
+            return false;
+        }
+        return true;
     }
 
     private UpdateEnhancementResponse createEnhancedRecord(

--- a/backend/src/main/java/site/gongnomok/enhanceditem/service/EnhancedItemService.java
+++ b/backend/src/main/java/site/gongnomok/enhanceditem/service/EnhancedItemService.java
@@ -2,6 +2,7 @@ package site.gongnomok.enhanceditem.service;
 
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.gongnomok.enhanceditem.ValidationCategory;
@@ -18,6 +19,7 @@ import site.gongnomok.item.exception.CannotFindItemException;
 
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EnhancedItemService {
@@ -56,7 +58,7 @@ public class EnhancedItemService {
         final ItemEnhanceServiceRequest enhanceDto
     ) {
 
-        if (validateEnhanceRequest(enhanceDto)) {
+        if (!validateEnhanceRequest(enhanceDto)) {
             return new UpdateEnhancementResponse(EnhanceResult.FAIL);
         }
 
@@ -78,10 +80,20 @@ public class EnhancedItemService {
     }
 
     private boolean validateEnhanceRequest(ItemEnhanceServiceRequest request) {
+
         ValidationCategory findCategory = ValidationCategory.findWithName(request.getCategory());
+
+        log.info("------------------- [검증 시작] ----------------------");
+        log.info("request.getIev() = {}", request.getIev());
+        log.info("findCategory.getMaximumUpgradableValue()={}", findCategory.getMaximumUpgradableValue());
+
         if (request.getIev() > findCategory.getMaximumUpgradableValue()) {
             return false;
         }
+
+        log.info("request.getSuccessCount()={}", request.getSuccessCount());
+        log.info("findCategory.getUpgradableCount()={}", findCategory.getUpgradableCount());
+
         if (request.getSuccessCount() > findCategory.getUpgradableCount()) {
             return false;
         }

--- a/backend/src/main/java/site/gongnomok/item/domain/repository/ItemQueryRepositoryImpl.java
+++ b/backend/src/main/java/site/gongnomok/item/domain/repository/ItemQueryRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.support.Querydsl;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
+import site.gongnomok.enhanceditem.domain.QEnhancedItem;
 import site.gongnomok.item.dto.ItemRankingRepositoryDto;
 import site.gongnomok.item.dto.api.itemlist.ItemListRequestServiceDto;
 import site.gongnomok.item.dto.api.itemlist.ItemResponseDto;
@@ -21,8 +22,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static site.gongnomok.global.entity.QEnhancedItem.enhancedItem;
-import static site.gongnomok.global.entity.QItem.item;
+import static site.gongnomok.enhanceditem.domain.QEnhancedItem.enhancedItem;
+import static site.gongnomok.item.domain.QItem.item;
 
 
 @Repository

--- a/backend/src/main/java/site/gongnomok/item/dto/ItemEnhanceRequest.java
+++ b/backend/src/main/java/site/gongnomok/item/dto/ItemEnhanceRequest.java
@@ -2,6 +2,7 @@ package site.gongnomok.item.dto;
 
 
 import lombok.*;
+import site.gongnomok.enhanceditem.ValidationCategory;
 import site.gongnomok.item.dto.service.ItemEnhanceServiceRequest;
 
 @Getter
@@ -12,6 +13,7 @@ import site.gongnomok.item.dto.service.ItemEnhanceServiceRequest;
 public class ItemEnhanceRequest {
 
     private String name;
+    private String category;
     private Integer iev;
     private Integer successCount;
     private Integer str;
@@ -32,6 +34,7 @@ public class ItemEnhanceRequest {
     public ItemEnhanceServiceRequest toServiceDto() {
         return ItemEnhanceServiceRequest.builder()
             .name(name)
+            .category(category)
             .iev(iev)
             .successCount(successCount)
             .str(str)

--- a/backend/src/main/java/site/gongnomok/item/dto/service/ItemEnhanceServiceRequest.java
+++ b/backend/src/main/java/site/gongnomok/item/dto/service/ItemEnhanceServiceRequest.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import site.gongnomok.enhanceditem.ValidationCategory;
 import site.gongnomok.enhanceditem.domain.EnhancedItem;
 
 @Getter
@@ -14,6 +15,7 @@ import site.gongnomok.enhanceditem.domain.EnhancedItem;
 public class ItemEnhanceServiceRequest {
 
     private String name;
+    private String category;
     private Integer iev;
     private Integer successCount;
     private Integer str;

--- a/backend/src/main/java/site/gongnomok/item/presentation/ItemController.java
+++ b/backend/src/main/java/site/gongnomok/item/presentation/ItemController.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import site.gongnomok.enhanceditem.dto.UpdateEnhancementResponse;
+import site.gongnomok.enhanceditem.service.EnhancedItemService;
 import site.gongnomok.item.dto.ItemEnhanceRequest;
 import site.gongnomok.item.dto.ItemEnhanceResponse;
 import site.gongnomok.item.dto.ItemRankingResponse;
@@ -30,6 +31,7 @@ import static site.gongnomok.member.domain.Role.USER;
 public class ItemController {
 
     private final ItemService itemService;
+    private final EnhancedItemService enhancedItemService;
 
     @GetMapping("/auth")
     public ResponseEntity<Void> auth(
@@ -86,23 +88,6 @@ public class ItemController {
         } catch (Exception e) {
             return ResponseEntity.badRequest().build();
         }
-    }
-
-    @GetMapping("/item/{itemId}/enhanced")
-    public ResponseEntity<ItemEnhanceResponse> enhancedItem(
-        @PathVariable("itemId") Long itemId
-    ) {
-        ItemEnhanceResponse result = itemService.findEnhanceItem(itemId);
-        return ResponseEntity.ok(result);
-    }
-
-    @PostMapping("/item/{itemId}/enhanced")
-    public ResponseEntity<UpdateEnhancementResponse> challengeEnhancedItem(
-        @PathVariable("itemId") Long itemId,
-        @RequestBody ItemEnhanceRequest enhanceDto
-    ) {
-        UpdateEnhancementResponse response = itemService.updateEnhanceItem(itemId, enhanceDto.toServiceDto());
-        return ResponseEntity.ok(response);
     }
 
 }

--- a/backend/src/main/java/site/gongnomok/member/domain/repository/MemberQueryRepositoryImpl.java
+++ b/backend/src/main/java/site/gongnomok/member/domain/repository/MemberQueryRepositoryImpl.java
@@ -8,8 +8,7 @@ import site.gongnomok.member.domain.Member;
 
 import java.util.Optional;
 
-import static site.gongnomok.global.entity.QMember.member;
-
+import static site.gongnomok.member.domain.QMember.member;
 
 @Repository
 @RequiredArgsConstructor
@@ -19,7 +18,8 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepository {
 
     @Override
     public Optional<Member> findMember(final String id, final String encryptedPassword) {
-        Member result = queryFactory.selectFrom(member)
+        Member result = queryFactory
+            .selectFrom(member)
             .where(idEqual(id), passwordEqual(encryptedPassword))
             .fetchOne();
 

--- a/frontend/css/common.css
+++ b/frontend/css/common.css
@@ -369,3 +369,39 @@
   border-width: 2px;
   border-color: black;
 }
+
+.red {
+  color: red
+}
+
+.primary-red {
+  color: rgb(255, 83, 83)
+}
+
+.whtie {
+  color: white
+}
+
+.orange {
+  color: orange
+}
+
+.purple {
+  color: rgb(164, 28, 255)
+}
+
+.blue {
+  color: rgb(41, 77, 255);
+}
+
+.yellow {
+  color: rgb(240, 240, 35);
+}
+
+.green {
+  color: rgb(0, 157, 0)
+}
+
+.pink {
+  color: rgb(255, 129, 221)
+}

--- a/frontend/css/index-lg.css
+++ b/frontend/css/index-lg.css
@@ -369,37 +369,7 @@
     font-size: 15px;
   }
 
-  .red {
-    color: red
-  }
-
-  .whtie {
-    color: white
-  }
-
-  .orange {
-    color: orange
-  }
-
-  .purple {
-    color: rgb(164, 28, 255)
-  }
-
-  .blue {
-    color: rgb(41, 77, 255);
-  }
-
-  .yellow {
-    color: rgb(240, 240, 35);
-  }
-
-  .green {
-    color: rgb(0, 157, 0)
-  }
-
-  .pink {
-    color: rgb(255, 129, 221)
-  }
+  
 
   .item-info-job span {
     margin-left: 6px;

--- a/frontend/css/index-md.css
+++ b/frontend/css/index-md.css
@@ -365,39 +365,7 @@
   .item-info-job {
     font-size: 15px;
   }
-
-  .red {
-    color: red
-  }
-
-  .whtie {
-    color: white
-  }
-
-  .orange {
-    color: orange
-  }
-
-  .purple {
-    color: rgb(164, 28, 255)
-  }
-
-  .blue {
-    color: rgb(41, 77, 255);
-  }
-
-  .yellow {
-    color: rgb(240, 240, 35);
-  }
-
-  .green {
-    color: rgb(0, 157, 0)
-  }
-
-  .pink {
-    color: rgb(255, 129, 221)
-  }
-
+  
   .item-info-job span {
     margin-left: 6px;
     margin-right: 6px;

--- a/frontend/css/index-sm.css
+++ b/frontend/css/index-sm.css
@@ -368,38 +368,6 @@
     font-size: 15px;
   }
 
-  .red {
-    color: red
-  }
-
-  .whtie {
-    color: white
-  }
-
-  .orange {
-    color: orange
-  }
-
-  .purple {
-    color: rgb(164, 28, 255)
-  }
-
-  .blue {
-    color: rgb(41, 77, 255);
-  }
-
-  .yellow {
-    color: rgb(240, 240, 35);
-  }
-
-  .green {
-    color: rgb(0, 157, 0)
-  }
-
-  .pink {
-    color: rgb(255, 129, 221)
-  }
-
   .item-info-job span {
     margin-left: 6px;
     margin-right: 6px;

--- a/frontend/css/index-xl.css
+++ b/frontend/css/index-xl.css
@@ -424,38 +424,6 @@
     font-size: 15px;
   }
 
-  .red {
-    color: red
-  }
-
-  .whtie {
-    color: white
-  }
-
-  .orange {
-    color: orange
-  }
-
-  .purple {
-    color: rgb(164, 28, 255)
-  }
-
-  .blue {
-    color: rgb(41, 77, 255);
-  }
-
-  .yellow {
-    color: rgb(240, 240, 35);
-  }
-
-  .green {
-    color: rgb(0, 157, 0)
-  }
-
-  .pink {
-    color: rgb(255, 129, 221)
-  }
-
   .item-info-job span {
     margin-left: 6px;
     margin-right: 6px;

--- a/frontend/css/index-xs.css
+++ b/frontend/css/index-xs.css
@@ -370,38 +370,6 @@
     font-size: 16px;
   }
 
-  .red {
-    color: red
-  }
-
-  .whtie {
-    color: white
-  }
-
-  .orange {
-    color: orange
-  }
-
-  .purple {
-    color: rgb(164, 28, 255)
-  }
-
-  .blue {
-    color: rgb(41, 77, 255);
-  }
-
-  .yellow {
-    color: rgb(240, 240, 35);
-  }
-
-  .green {
-    color: rgb(0, 157, 0)
-  }
-
-  .pink {
-    color: rgb(255, 129, 221)
-  }
-
   .item-info-job span {
     margin-left: 8px;
     margin-right: 8px;

--- a/frontend/css/index-xxl.css
+++ b/frontend/css/index-xxl.css
@@ -366,38 +366,6 @@
     font-size: 15px;
   }
 
-  .red {
-    color: red
-  }
-
-  .whtie {
-    color: white
-  }
-
-  .orange {
-    color: orange
-  }
-
-  .purple {
-    color: rgb(164, 28, 255)
-  }
-
-  .blue {
-    color: rgb(41, 77, 255);
-  }
-
-  .yellow {
-    color: rgb(240, 240, 35);
-  }
-
-  .green {
-    color: rgb(0, 157, 0)
-  }
-
-  .pink {
-    color: rgb(255, 129, 221)
-  }
-
   .item-info-job span {
     margin-left: 6px;
     margin-right: 6px;

--- a/frontend/src/components/Item/BestRecordItem.jsx
+++ b/frontend/src/components/Item/BestRecordItem.jsx
@@ -41,6 +41,8 @@ export default function BestRecordItem({ itemId, info }) {
       return 'yellow'
     } else if (iev >= 57 && iev <= 73) {
       return 'green'
+    } else if (iev > 73) {
+      return 'primary-red'
     }
 
     return 'white';

--- a/frontend/src/components/Item/ItemSimulator.jsx
+++ b/frontend/src/components/Item/ItemSimulator.jsx
@@ -502,6 +502,7 @@ export default function ItemSimulator() {
   function createChallengeForm() {
     return {
       name: challengerName,
+      category: CATEGORY_NAME.get(info?.category),
       iev: calculateIEV(),
       successCount: upgradedCount,
       str: str - defaultStr.current,
@@ -648,7 +649,7 @@ export default function ItemSimulator() {
                 className="item-record-challenge-btn"
                 onClick={challengeRecordButtonClicked}
                 onMouseUp={() => document.activeElement.blur()}
-              >기록으로 등록하기</button>
+              >기록에 도전하기</button>
             </section>
           </section>
 


### PR DESCRIPTION
사용자가 임의로 JSON 요청을 보내 주문서로 만드는 것이 불가능한 능력치의 아이템을 기록으로 도전하는 문제가 있었습니다.
서버 검증 로직을 추가해 부적절한 요청이 처리되지 않도록 하였습니다.
- 아이템 카테고리별 최대 강화될 수 있는 횟수
- 아이템별 주문서로 강화 가능한 능력치(IEV)의 최댓값
두가지 값을 사용해 검증로직을 추가하였습니다.
