### PR TITLE
[BE, FE] [버그 수정] 공격속도가 null로 처리되는 버그 수정

### DIFF
--- a/backend/src/main/java/site/gongnomok/enhanceditem/service/EnhancedItemService.java
+++ b/backend/src/main/java/site/gongnomok/enhanceditem/service/EnhancedItemService.java
@@ -73,8 +73,8 @@ public class EnhancedItemService {
         EnhancedItem enhancedItem = enhancedItemOptional
             .orElseThrow(() -> new EnhancedItemException(NOT_FOUND_ENHANCED_ID));
 
-        if (enhancedItem.getIev() < enhanceDto.getIev()) {
-            // 기록이 기존의 것보다 높을 경우
+        if (enhancedItem.getIev() <= enhanceDto.getIev()) {
+            // 기록이 기존의 것과 같거나 높을 경우
             return updateEnhancedRecord(enhancedItem, enhanceDto);
         }
 

--- a/backend/src/main/java/site/gongnomok/item/domain/AttackSpeed.java
+++ b/backend/src/main/java/site/gongnomok/item/domain/AttackSpeed.java
@@ -3,6 +3,7 @@ package site.gongnomok.item.domain;
 import java.util.Arrays;
 
 public enum AttackSpeed {
+    NONE,
     VERY_SLOW,
     SLOW,
     NORMAL,
@@ -10,7 +11,7 @@ public enum AttackSpeed {
     VERY_FAST;
 
     public static AttackSpeed stringToAttackSpeed(String data) {
-        if (data == null) return null;
+        if (data == null) return NONE;
         return Arrays.stream(values())
                 .filter((value) -> {
                     return value.name().equals(data);

--- a/backend/src/main/java/site/gongnomok/item/dto/response/ItemDetailsResponse.java
+++ b/backend/src/main/java/site/gongnomok/item/dto/response/ItemDetailsResponse.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import site.gongnomok.item.domain.AttackSpeed;
 import site.gongnomok.item.domain.Item;
 import site.gongnomok.item.dto.api.ItemRequiredDto;
 import site.gongnomok.item.dto.api.ItemRequiredJob;

--- a/backend/src/main/java/site/gongnomok/item/dto/response/ItemExceptionResponse.java
+++ b/backend/src/main/java/site/gongnomok/item/dto/response/ItemExceptionResponse.java
@@ -1,0 +1,14 @@
+package site.gongnomok.item.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ItemExceptionResponse {
+    private int code;
+    private String message;
+}

--- a/backend/src/main/java/site/gongnomok/item/presentation/ItemController.java
+++ b/backend/src/main/java/site/gongnomok/item/presentation/ItemController.java
@@ -57,13 +57,11 @@ public class ItemController {
     }
 
     @GetMapping("/item/{itemId}")
-    public ResponseEntity<ItemDetailsResponse> item(@PathVariable("itemId") Long itemId) {
-        try {
-            ItemDetailsResponse findItem = itemService.findItemById(itemId);
-            return ResponseEntity.ok(findItem);
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().build();
-        }
+    public ResponseEntity<ItemDetailsResponse> item(
+        @PathVariable("itemId") Long itemId
+    ) {
+        final ItemDetailsResponse findItem = itemService.findItemById(itemId);
+        return ResponseEntity.ok(findItem);
     }
 
 }

--- a/backend/src/main/java/site/gongnomok/item/presentation/ItemControllerAdvice.java
+++ b/backend/src/main/java/site/gongnomok/item/presentation/ItemControllerAdvice.java
@@ -1,0 +1,23 @@
+package site.gongnomok.item.presentation;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import site.gongnomok.global.exception.ItemException;
+import site.gongnomok.item.dto.response.ItemExceptionResponse;
+
+
+@Slf4j
+@RestControllerAdvice(assignableTypes = ItemController.class)
+public class ItemControllerAdvice {
+
+    @ExceptionHandler(ItemException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ItemExceptionResponse itemException(ItemException ex) {
+        return new ItemExceptionResponse(ex.getCode(), ex.getMessage());
+    }
+
+}

--- a/backend/src/test/java/site/gongnomok/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/site/gongnomok/domain/comment/service/CommentServiceTest.java
@@ -1,5 +1,6 @@
 package site.gongnomok.domain.comment.service;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +12,13 @@ import site.gongnomok.comment.dto.request.CommentDeleteServiceDto;
 import site.gongnomok.comment.service.CommentService;
 import site.gongnomok.global.exception.CommentException;
 import site.gongnomok.global.util.SecurityUtil;
+import site.gongnomok.item.domain.AttackSpeed;
+import site.gongnomok.item.domain.Category;
+import site.gongnomok.item.dto.api.ItemRequiredDto;
+import site.gongnomok.item.dto.api.ItemRequiredJob;
+import site.gongnomok.item.dto.request.ItemCreateRequest;
+import site.gongnomok.item.dto.request.ItemStatusRequest;
+import site.gongnomok.item.service.ItemService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -22,6 +30,37 @@ class CommentServiceTest {
 
     @Autowired
     CommentService commentService;
+
+    @Autowired
+    ItemService itemService;
+
+    @BeforeEach
+    void beforeEach() {
+
+        final String ITEM_NAME_PREFIX = "item_";
+
+        for (long i = 1; i <= 30; i++) {
+            final Long ITEM_ID = i;
+            final String ITEM_NAME = ITEM_NAME_PREFIX + i;
+
+            final ItemRequiredJob requiredJob = ItemRequiredJob.makeDefault();
+            final ItemRequiredDto requiredDto = ItemRequiredDto.makeDefault();
+            final ItemStatusRequest status = ItemStatusRequest.makeDefaultRequest();
+
+            ItemCreateRequest createRequest = ItemCreateRequest.builder()
+                .id(ITEM_ID)
+                .name(ITEM_NAME)
+                .requiredJob(requiredJob)
+                .required(requiredDto)
+                .category(Category.CLAW.name())
+                .status(status)
+                .upgradableCount(7)
+                .attackSpeed(AttackSpeed.FAST.name())
+                .knockBackPercent(0)
+                .build();
+            itemService.createItem(createRequest);
+        }
+    }
 
     @Test
     @DisplayName("댓글 생성")
@@ -48,51 +87,6 @@ class CommentServiceTest {
         assertThat(createResponse.getName()).isEqualTo(USERNAME);
         assertThat(createResponse.getCreatedDate()).isNotNull();
     }
-
-//    @Test
-//    @DisplayName("아이템 댓글 첫페이지 No Offset")
-//    void comment_no_offset_first_page() {
-//        Long itemId = 5L;
-//        for (int i = 1; i <= 30; i++) {
-//            commentService.createComment(
-//                CommentCreateServiceDto.builder()
-//                    .name("abc" + i)
-//                    .password("password")
-//                    .content("testcomment" + i)
-//                    .build(),
-//                itemId
-//            );
-//        }
-//
-//        List<CommentResponse> results = commentService.fetchComment(itemId, null, 20);
-//
-//        assertThat(results).hasSize(20);
-//    }
-
-//    @Test
-//    @DisplayName("아이템 댓글 No Offset")
-//    @Transactional
-//    void comment_no_offset_page() {
-//        Long itemId = 5L;
-//        for (int i = 1; i <= 30; i++) {
-//            commentService.createComment(
-//                CommentCreateServiceDto.builder()
-//                    .name("abc" + i)
-//                    .password("password")
-//                    .content("test content")
-//                    .build(),
-//                itemId
-//            );
-//        }
-//        // 마지막으로 등록한 댓글 1개를 가져옴
-//        List<CommentResponse> commentFirstPage = commentService.fetchComment(itemId, null, 1);
-//        Long lastCommentId = commentFirstPage.get(0).getCommentId();
-//
-//        List<CommentResponse> results = commentService.fetchComment(itemId, lastCommentId, 20);
-//
-//        assertThat(results).hasSize(20);
-//    }
-
 
     @Test
     @DisplayName("댓글 삭제 성공")

--- a/frontend/src/components/Item/ItemSimulator.jsx
+++ b/frontend/src/components/Item/ItemSimulator.jsx
@@ -105,6 +105,8 @@ export default function ItemSimulator() {
       setPhyDef(copy.status.phyDef.normal);
       setMgDef(copy.status.mgDef.normal);
       setAcc(copy.status.acc.normal);
+
+
       setAvo(copy.status.avo.normal);
       setMove(copy.status.move.normal);
       setJump(copy.status.jump.normal);
@@ -619,7 +621,7 @@ export default function ItemSimulator() {
 
                 <div className="item-info-status">
                   <span>장비분류 : {CATEGORY_NAME.get(info?.category)}</span>
-                  {info?.attackSpeed != null && <span>공격속도 : {ATTACK_SPEED.get(info?.attackSpeed)}</span>}
+                  {(info?.attackSpeed !== null || info?.attackSpeed !== 'NONE' ) && <span>공격속도 : {ATTACK_SPEED.get(info?.attackSpeed)}</span>}
                   {str > 0 && <span>STR : +{str}</span>}
                   {dex > 0 && <span>DEX : +{dex}</span>}
                   {intel > 0 && <span>INT : +{intel}</span>}

--- a/frontend/src/components/Item/ItemSimulator.jsx
+++ b/frontend/src/components/Item/ItemSimulator.jsx
@@ -92,6 +92,7 @@ export default function ItemSimulator() {
       const response = await axios.get(`${BASE_URI}/api/item/${itemId}`, { withCredentials: true })
       const data = response.data;
       const copy = JSON.parse(JSON.stringify(data));
+      console.log(data)
       setInfoCopy({...response.data});
       setInfo(data);
 

--- a/frontend/src/global/uri.js
+++ b/frontend/src/global/uri.js
@@ -1,8 +1,8 @@
 // export const BASE_URI = "http://34.64.91.129:8080"
-// export const BASE_URI = "http://localhost:8080"
+export const BASE_URI = "http://localhost:8080"
 // export const BASE_URI = "//gongnomok.site:8080"
 // export const BASE_URI = "https://gongnomok.site:8080"
-export const BASE_URI = "https://gongnomok.site"
+// export const BASE_URI = "https://gongnomok.site"
 
 
 


### PR DESCRIPTION
공격속도가 없는 장비의 경우 `attack_speed` 컬럼의 값이 `<null>` 로 지정되어 있기 때문에 문제가 발생했습니다.
1. `attack_speed` 컬럼에 `NONE` 속성을 추가한다.
2. 아이템이 공격속도를 가지지 않는 경우 NONE 값을 가지도록 한다.
3. Item 테이블의 스키마를 수정한다.
   1. attack_speed 컬럼 값에 NONE이 들어갈 수 있도록 수정
   2. `AttackSpeed` 열거형에 NONE을 추가
   3. ddl-auto가 update 인상태에서 애플리케이션을 실행
4. 데이터베이스에서 `attack_speed` 컬럼값이 <null>인 모든 row의 attack_speed 컬럼을 `NONE` 으로 변경한다. 
```sql
UPDATE item
SET attack_speed = ’NONE’
WHERE attack_speed is null;
```
5. 프론트 측에서 응답으로 받아왔을 때 공격속도 부분이 `NONE` 이면 공격속도를 표시하지 않도록 수정한다.
   1. 기존에는 `null`일 때만 표시하지 않는 것으로 되어있었다.