### PR TITLE
[BE] Refactor: 검증로직 분리

### DIFF
--- a/backend/src/main/java/site/gongnomok/enhanceditem/domain/EnhanceItemValidator.java
+++ b/backend/src/main/java/site/gongnomok/enhanceditem/domain/EnhanceItemValidator.java
@@ -4,8 +4,7 @@ import org.springframework.stereotype.Component;
 import site.gongnomok.enhanceditem.dto.request.ItemEnhanceServiceRequest;
 import site.gongnomok.global.exception.EnhancedItemException;
 
-import static site.gongnomok.global.exception.ExceptionCode.INVALID_ENHANCED_SCORE_REQUST;
-import static site.gongnomok.global.exception.ExceptionCode.INVALID_ENHANCED_SUCCESS_REQUEST;
+import static site.gongnomok.global.exception.ExceptionCode.*;
 
 
 @Component
@@ -35,7 +34,7 @@ public class EnhanceItemValidator {
         final int maximumScore = scroll.getMaximumScore(upgradable);
         final int actualScore = scroll.calculateScore(success);
         if (actualScore > maximumScore) {
-            throw new EnhancedItemException(INVALID_ENHANCED_SCORE_REQUST);
+            throw new EnhancedItemException(INVALID_ENHANCED_SCORE_REQUEST);
         }
     }
 }

--- a/backend/src/main/java/site/gongnomok/enhanceditem/domain/EnhanceItemValidator.java
+++ b/backend/src/main/java/site/gongnomok/enhanceditem/domain/EnhanceItemValidator.java
@@ -1,0 +1,41 @@
+package site.gongnomok.enhanceditem.domain;
+
+import org.springframework.stereotype.Component;
+import site.gongnomok.enhanceditem.dto.request.ItemEnhanceServiceRequest;
+import site.gongnomok.global.exception.EnhancedItemException;
+
+import static site.gongnomok.global.exception.ExceptionCode.INVALID_ENHANCED_SCORE_REQUST;
+import static site.gongnomok.global.exception.ExceptionCode.INVALID_ENHANCED_SUCCESS_REQUEST;
+
+
+@Component
+public class EnhanceItemValidator {
+
+    public void validateRequest(final ItemEnhanceServiceRequest request) {
+        validateSuccessCount(request.getSuccess());
+        validateScore(request.getSuccess(), request.getScroll(), request.getUpgradable());
+    }
+
+    private void validateSuccessCount(final EnhanceSuccess success) {
+        final int ten = success.getTenSuccessCount();
+        final int sixty = success.getSixtySuccessCount();
+        final int hundred = success.getHundredSuccessCount();
+
+        final int total = ten + sixty + hundred;
+        if (total > 10) {
+            throw new EnhancedItemException(INVALID_ENHANCED_SUCCESS_REQUEST);
+        }
+    }
+
+    private void validateScore(
+        final EnhanceSuccess success,
+        final EnhanceScroll scroll,
+        final int upgradable
+    ) {
+        final int maximumScore = scroll.getMaximumScore(upgradable);
+        final int actualScore = scroll.calculateScore(success);
+        if (actualScore > maximumScore) {
+            throw new EnhancedItemException(INVALID_ENHANCED_SCORE_REQUST);
+        }
+    }
+}

--- a/backend/src/main/java/site/gongnomok/enhanceditem/domain/EnhancedItem.java
+++ b/backend/src/main/java/site/gongnomok/enhanceditem/domain/EnhancedItem.java
@@ -45,10 +45,6 @@ public class EnhancedItem {
         status = dto.getStatus();
     }
 
-    public void changeScore(int score) {
-        this.score = score;
-    }
-
     public void changeItem(Item item) {
         this.item = item;
     }

--- a/backend/src/main/java/site/gongnomok/enhanceditem/domain/EnhancedItem.java
+++ b/backend/src/main/java/site/gongnomok/enhanceditem/domain/EnhancedItem.java
@@ -36,6 +36,10 @@ public class EnhancedItem {
     @Enumerated(EnumType.STRING)
     private EnhanceScroll scroll;
 
+    public static EnhancedItem of(ItemEnhanceServiceRequest dto) {
+
+    }
+
     public void changeInfo(ItemEnhanceServiceRequest dto) {
         name = dto.getName();
         iev = dto.getIev();

--- a/backend/src/main/java/site/gongnomok/enhanceditem/presentation/exhandler/EnhancedItemControllerAdvice.java
+++ b/backend/src/main/java/site/gongnomok/enhanceditem/presentation/exhandler/EnhancedItemControllerAdvice.java
@@ -1,0 +1,19 @@
+package site.gongnomok.enhanceditem.presentation.exhandler;
+
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import site.gongnomok.global.exception.EnhancedItemException;
+
+@RestControllerAdvice
+public class EnhancedItemControllerAdvice {
+
+    @ExceptionHandler(EnhancedItemException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public void enhancedItemException() {
+
+    }
+
+}

--- a/backend/src/main/java/site/gongnomok/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/site/gongnomok/global/exception/ExceptionCode.java
@@ -17,7 +17,9 @@ public enum ExceptionCode {
     NOT_FOUND_SCROLL_NAME(1005, "요청한 이름에 해당하는 주문서가 존재하지 않습니다."),
 
     INVALID_USER_NAME(2000, "존재하지 않는 사용자 입니다."),
-    INVALID_PASSWORD(2001, "비밀번호가 일치하지 않습니다.");
+    INVALID_PASSWORD(2001, "비밀번호가 일치하지 않습니다."),
+    INVALID_ENHANCED_SUCCESS_REQUEST(2002, "강화 성공 횟수는 10회를 넘을 수 없습니다."),
+    INVALID_ENHANCED_SCORE_REQUST(2003, "강화 점수가 최대치를 넘어섰습니다.");
 
     private final int code;
     private final String message;

--- a/backend/src/main/java/site/gongnomok/global/exception/ExceptionCode.java
+++ b/backend/src/main/java/site/gongnomok/global/exception/ExceptionCode.java
@@ -19,7 +19,7 @@ public enum ExceptionCode {
     INVALID_USER_NAME(2000, "존재하지 않는 사용자 입니다."),
     INVALID_PASSWORD(2001, "비밀번호가 일치하지 않습니다."),
     INVALID_ENHANCED_SUCCESS_REQUEST(2002, "강화 성공 횟수는 10회를 넘을 수 없습니다."),
-    INVALID_ENHANCED_SCORE_REQUST(2003, "강화 점수가 최대치를 넘어섰습니다.");
+    INVALID_ENHANCED_SCORE_REQUEST(2003, "강화 점수가 최대치를 넘어섰습니다.");
 
     private final int code;
     private final String message;


### PR DESCRIPTION
### 문제사항
- 검증로직이 서비스계층에 위치해 서비스에서 요청데이터를 검증하는 책임을 가지고 있었다.
- 검증로직을 처리하는 함수가 private으로 정의되어 테스트하기 어렵다.
- 검증로직과 테스트하기 어려운 DB접근 코드가 한곳에 위치하여 테스트하기 어렵다.

### 해결방안
- 강화아이템 검증클래스를 정의하여 강화아이템에 대한 검증로직은 모두 이곳에 위치하도록 하였다.
- 강화아이템 도전요청에 필요한 검증로직을 하나로 모은 public 메서드를 정의한다.
- 서비스 계층에서 검증클래스를 주입받아 사용한다.