### PR TITLE
[BE] fix: 벌크연산 수행 전 영속성컨텍스트 정리

### DIFF
--- a/backend/gongnomok-data/src/main/java/site/gongnomok/data/comment/domain/repository/CommentJpaRepository.java
+++ b/backend/gongnomok-data/src/main/java/site/gongnomok/data/comment/domain/repository/CommentJpaRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("delete from Comment c where c.id in :ids")
     void deleteByIdIn(List<Long> ids);
 }

--- a/backend/gongnomok-data/src/main/java/site/gongnomok/data/management/domain/repository/ReportCommentJpaRepository.java
+++ b/backend/gongnomok-data/src/main/java/site/gongnomok/data/management/domain/repository/ReportCommentJpaRepository.java
@@ -12,7 +12,7 @@ public interface ReportCommentJpaRepository extends JpaRepository<ReportComment,
 
     public Optional<ReportComment> findReportCommentByCommentId(Long comment_id);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("delete from ReportComment rc where rc.id in :ids")
     void deleteAllByReportId(List<Long> ids);
 }


### PR DESCRIPTION
- `@Modifying`의 `clearAutomatically` 옵션을 설정해 벌크쿼리가 수행되기 전 영속성 컨텍스트를 비워주도록 설정하였습니다.
- 벌크연산은 1차 캐시를 비롯한 영속성 컨텍스트를 무시하고 수행되기 때문에 영속성 컨텍스트가 데이터의 변경을 알 수 없습니다. 이를 방지하기 위해서 벌크쿼리가 수행되기 전 flush와 영속성 컨텍스트를 비워주는 과정이 필요합니다.