### PR TITLE
[BE] bugfix: 등록 금칙어가 전달되지 않는 버그 수정

### DIFF
--- a/backend/gongnomok-api/src/main/java/site/gongnomok/api/management/ManagementController.java
+++ b/backend/gongnomok-api/src/main/java/site/gongnomok/api/management/ManagementController.java
@@ -131,7 +131,7 @@ public class ManagementController {
     @PostMapping("/manage/banword")
     public ResponseEntity<Void> addBanWord(
         @AdminAuth Accessor accessor,
-        final BanWordAddRequest request
+        @RequestBody final BanWordAddRequest request
     ) {
         Long createdId = banWordService.addBanWord(request.getWord());
         return ResponseEntity

--- a/backend/gongnomok-common/src/main/java/site/gongnomok/common/banword/dto/request/BanWordAddRequest.java
+++ b/backend/gongnomok-common/src/main/java/site/gongnomok/common/banword/dto/request/BanWordAddRequest.java
@@ -1,10 +1,10 @@
 package site.gongnomok.common.banword.dto.request;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class BanWordAddRequest {
-    final String word;
+    private String word;
 }

--- a/backend/gongnomok-core/src/main/java/site/gongnomok/core/banword/BanWordService.java
+++ b/backend/gongnomok-core/src/main/java/site/gongnomok/core/banword/BanWordService.java
@@ -8,6 +8,9 @@ import site.gongnomok.common.exception.BanWordException;
  * <h2>금칙어 서비스 인터페이스</h2>
  * 금칙어 관리를 위한 서비스 인터페이스 입니다.<br>
  * 이 인터페이스는 금칙어 목록 조회, 추가 및 삭제 기능을 제공합니다.
+ *
+ * @see BaseBanWordService
+ *
  * @author Jaehoon So
  * @version 1.0.0
  */

--- a/backend/gongnomok-core/src/main/java/site/gongnomok/core/banword/BaseBanWordService.java
+++ b/backend/gongnomok-core/src/main/java/site/gongnomok/core/banword/BaseBanWordService.java
@@ -2,6 +2,7 @@ package site.gongnomok.core.banword;
 
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -39,6 +40,7 @@ import java.util.List;
  * @version 1.0.0
  */
 @Service
+@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class BaseBanWordService implements BanWordService {
@@ -64,6 +66,7 @@ public class BaseBanWordService implements BanWordService {
     @Override
     @Transactional
     public Long addBanWord(String word) {
+        log.info("새로운 금칙어 등록={}", word);
         BanWord banWord = new BanWord(word);
         banWordRepository.save(banWord);
 

--- a/backend/gongnomok-core/src/main/java/site/gongnomok/core/banword/BaseBanWordService.java
+++ b/backend/gongnomok-core/src/main/java/site/gongnomok/core/banword/BaseBanWordService.java
@@ -48,7 +48,7 @@ public class BaseBanWordService implements BanWordService {
 
     @Override
     public PaginatedBanWordResponse fetchBanWordList(Pageable pageable) {
-        Page<BanWord> result = banWordRepository.findAll(pageable);
+        Page<BanWord> result = banWordRepository.findAllByOrderByIdDesc(pageable);
         List<BanWordDto> content = banWordConverter.toDtoList(result.getContent());
 
         return PaginatedBanWordResponse.builder()

--- a/backend/gongnomok-data/src/main/java/site/gongnomok/data/banword/domain/repository/BanWordRepository.java
+++ b/backend/gongnomok-data/src/main/java/site/gongnomok/data/banword/domain/repository/BanWordRepository.java
@@ -24,5 +24,5 @@ import site.gongnomok.data.banword.domain.BanWord;
  */
 public interface BanWordRepository extends JpaRepository<BanWord, Long> {
 
-    Page<BanWord> findAll(Pageable pageable);
+    Page<BanWord> findAllByOrderByIdDesc(Pageable pageable);
 }


### PR DESCRIPTION
프론트엔드에서 전달한 새로운 금칙어가 전달되지 않는 버그를 수정하였습니다.
원인은 컨트롤러 메서드 파라미터의 @RequestBody 애노테이션의 부재, 그리고 @RequestBody 가 매핑할 수 있는 조건을 만족하지 못했기 때문이였습니다.
@RequestBody로 매핑하기 위해서는 DTO 객체가 다음 조건 중 하나를 만족해야합니다.
1. 기본생성자 + public Getter
2. 기본생성자 + (모든 접근 제어자) Setter

이전 코드의 경우 DTO 객체에 기본생성자가 존재하지 않았기 때문에 매핑에 실패하였습니다.