### PR TITLE
[Fix] X-Real-IP 헤더 사용

### DIFF
--- a/backend/gongnomok-api/src/main/java/site/gongnomok/api/enhanceditem/EnhancedItemController.java
+++ b/backend/gongnomok-api/src/main/java/site/gongnomok/api/enhanceditem/EnhancedItemController.java
@@ -33,7 +33,7 @@ public class EnhancedItemController {
         @RequestBody ItemEnhanceRequest enhanceDto,
         final HttpServletRequest request
     ) {
-        String address = request.getHeader("X-FORWARDED-FOR") != null ? request.getHeader("X-FORWARDED-FOR") : request.getRemoteAddr();
+        String address = request.getHeader("X-Real-IP") != null ? request.getHeader("X-Real-IP") : request.getRemoteAddr();
         UpdateEnhancementResponse response = enhancedItemService.updateEnhanceItem(itemId, enhanceDto.toServiceDto(), address);
         return ResponseEntity.ok(response);
     }

--- a/backend/gongnomok-api/src/main/java/site/gongnomok/api/management/RecordManagementController.java
+++ b/backend/gongnomok-api/src/main/java/site/gongnomok/api/management/RecordManagementController.java
@@ -34,7 +34,7 @@ public class RecordManagementController {
         @RequestParam("size") long size,
         @RequestParam("name") String name
     ) {
-        log.info("lastId={}, size={}, name={}", lastId, size, name);
+//        log.info("lastId={}, size={}, name={}", lastId, size, name);
         List<RecordResponse> result = recordLogService.readRecordLog(lastId, size, name);
         return ResponseEntity.ok(result);
     }


### PR DESCRIPTION
사용자 IP 주소를 가져오기 위해 `X-Forwarded-For` 대신 `X-Real-IP` 헤더를 사용하였습니다.