### PR TITLE
[BE] 복구쿼리 오류 수정

### DIFF
--- a/backend/gongnomok-api/src/main/java/site/gongnomok/api/management/RecordManagementController.java
+++ b/backend/gongnomok-api/src/main/java/site/gongnomok/api/management/RecordManagementController.java
@@ -68,8 +68,8 @@ public class RecordManagementController {
      */
     @DeleteMapping("/record/logs")
     @AdminOnly
-    public ResponseEntity<Void> deleteRecord(@AdminAuth Accessor accessor, final String name) {
-        recordLogService.deleteRecord(name);
+    public ResponseEntity<Void> deleteRecord(@AdminAuth Accessor accessor, final String ip) {
+        recordLogService.deleteRecord(ip);
         return ResponseEntity.ok(null);
     }
     

--- a/backend/gongnomok-core/src/main/java/site/gongnomok/core/management/log/RecordLogService.java
+++ b/backend/gongnomok-core/src/main/java/site/gongnomok/core/management/log/RecordLogService.java
@@ -70,7 +70,7 @@ public class RecordLogService {
     public void deleteRecord(final String ip) {
         List<EnhanceRecord> findLogs = recordLogRepository.findByIp(ip); // 지정된 IP로 저장된 로그 조회
         recordLogRepository.deleteByIp(ip); // 지정된 IP로 저장된 로그 삭제
-        findLogs.stream()
+        findLogs
                 .forEach((log) -> {
                     Item item = itemRepository.findById(log.getItem().getId())
                         .orElseThrow(() -> new IllegalArgumentException(String.format("item_id=[%d]인 아이템을 찾을 수 없습니다.", log.getItem().getId())));
@@ -79,13 +79,13 @@ public class RecordLogService {
     }
     
     public void clean() {
-        List<Item> allItems = itemRepository.findAll();
-        log.info("찾아온 아이템 [{}]개", allItems.size());
-        
-        for (Item item: allItems) {
-            Long itemId = item.getId();
-            restoreSingleRecord(itemId);
-        }
+        List<Item> items = itemRepository.findAll();
+        log.info("찾아온 아이템 [{}]개", items.size());
+
+        items
+            .forEach((item) -> {
+                restoreSingleRecord(item.getId());
+            });
     }
 
     private void restoreSingleRecord(Long itemId) {

--- a/backend/gongnomok-core/src/main/java/site/gongnomok/core/management/log/RecordLogService.java
+++ b/backend/gongnomok-core/src/main/java/site/gongnomok/core/management/log/RecordLogService.java
@@ -70,6 +70,7 @@ public class RecordLogService {
     public void deleteRecord(final String ip) {
         List<EnhanceRecord> findLogs = recordLogRepository.findByIp(ip); // 지정된 IP로 저장된 로그 조회
         recordLogRepository.deleteByIp(ip); // 지정된 IP로 저장된 로그 삭제
+//        enhancedItemRepository.deleteByIp(ip); // 지정된 IP로 저장된 기록 삭제. 로그가 있으면 UPDATE 쿼리가 전달 되기 때문에 굳이 삭제할 필요는 없다.
         findLogs
                 .forEach((log) -> {
                     Item item = itemRepository.findById(log.getItem().getId())

--- a/backend/gongnomok-core/src/main/java/site/gongnomok/core/management/log/RecordLogService.java
+++ b/backend/gongnomok-core/src/main/java/site/gongnomok/core/management/log/RecordLogService.java
@@ -78,7 +78,8 @@ public class RecordLogService {
         
         for (Item item: allItems) {
             Long itemId = item.getId();
-            log.info("item_id={}에 대해 복구 작업을 진행", itemId);
+            
+            log.info("item_id={}, item_name={} 복구", itemId, item.getName());
             Optional<EnhanceRecord> recordLog = recordLogRepository.findBestRecordOf(itemId);
             Optional<EnhancedItem> record = enhancedItemRepository.findByItemId(itemId);
 

--- a/backend/gongnomok-data/src/main/java/site/gongnomok/data/enhanceditem/domain/repository/EnhancedItemRepository.java
+++ b/backend/gongnomok-data/src/main/java/site/gongnomok/data/enhanceditem/domain/repository/EnhancedItemRepository.java
@@ -15,5 +15,7 @@ public interface EnhancedItemRepository extends JpaRepository<EnhancedItem, Long
     
     @Query("select e from EnhancedItem e where e.item.id = :itemId")
     public Optional<EnhancedItem> findByItemId(Long itemId);
+
+    public void deleteByIp(String ip);
     
 }

--- a/backend/gongnomok-data/src/main/java/site/gongnomok/data/management/record/repository/RecordLogRepository.java
+++ b/backend/gongnomok-data/src/main/java/site/gongnomok/data/management/record/repository/RecordLogRepository.java
@@ -15,6 +15,6 @@ public interface RecordLogRepository extends JpaRepository<EnhanceRecord, Long>,
     @Query("delete from EnhanceRecord er where er.challengerName = :name")
     public void deleteByName(String name);
 
-    @Query("select er1 from EnhanceRecord er1 where er1.score = (select max(er2.score) from EnhanceRecord er2 where er2.item.id = :itemId) order by er1.id desc limit 1")
+    @Query("select er1 from EnhanceRecord er1 where er1.score = (select max(er2.score) from EnhanceRecord er2 where er2.item.id = :itemId) and er1.item.id = :itemId order by er1.id desc limit 1")
     public Optional<EnhanceRecord> findBestRecordOf(Long itemId);
 }

--- a/backend/gongnomok-data/src/main/java/site/gongnomok/data/management/record/repository/RecordLogRepository.java
+++ b/backend/gongnomok-data/src/main/java/site/gongnomok/data/management/record/repository/RecordLogRepository.java
@@ -6,14 +6,18 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import site.gongnomok.data.management.record.domain.EnhanceRecord;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface RecordLogRepository extends JpaRepository<EnhanceRecord, Long>, RecordLogQueryRepository {
 
+    @Query("select er from EnhanceRecord er join fetch er.item where er.ip = :ip")
+    public List<EnhanceRecord> findByIp(String ip);
+    
     @Modifying(clearAutomatically = true)
-    @Query("delete from EnhanceRecord er where er.challengerName = :name")
-    public void deleteByName(String name);
+    @Query("delete from EnhanceRecord er where er.ip = :ip")
+    public void deleteByIp(String ip);
 
     @Query("select er1 from EnhanceRecord er1 where er1.score = (select max(er2.score) from EnhanceRecord er2 where er2.item.id = :itemId) and er1.item.id = :itemId order by er1.id desc limit 1")
     public Optional<EnhanceRecord> findBestRecordOf(Long itemId);


### PR DESCRIPTION
- 복구 쿼리에서 특정 아이템의 로그를 제대로 조회하지 못하는 버그를 수정하였습니다.
- item_id로 로그를 검색하는 쿼리였는데 item_id일치 조건을 서브쿼리에만 삽입해 접수 일치여부만 보고 로그를 찾아오는 버그였습니다.